### PR TITLE
Allow transcripts to support many links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 3.0.0
+#### Changes
+* Transcripts now has many links instead of one.
+* `has_many` association can take either a collection or a single object.
+
 ### 2.0.2
 #### Changes
 * More strict faraday_middleware dependency.

--- a/lib/npr/api/response.rb
+++ b/lib/npr/api/response.rb
@@ -19,7 +19,6 @@ module NPR
 
         @_response = response
         @raw       = response.body
-
         @version = @raw["version"]
 
         if list = @raw["list"]

--- a/lib/npr/concern/attr_typecast.rb
+++ b/lib/npr/concern/attr_typecast.rb
@@ -34,7 +34,11 @@ module NPR
       #------------------
 
       def string_time_parse(value)
-        !value.empty? ? Time.parse(value) : nil
+        begin
+          !value.empty? ? Time.parse(value) : nil
+        rescue ArgumentError
+          nil
+        end
       end
 
       #------------------

--- a/lib/npr/concern/relation.rb
+++ b/lib/npr/concern/relation.rb
@@ -84,7 +84,7 @@ module NPR
           collection = []
 
           if node = json[relation[:key]]
-            node.each do |obj|
+            Array.wrap(node).each do |obj|
               collection.push relation[:class_name].new(obj)
             end
           end

--- a/lib/npr/entity/transcript.rb
+++ b/lib/npr/entity/transcript.rb
@@ -4,7 +4,7 @@
 module NPR
   module Entity
     class Transcript < Base
-      has_one "link", :class_name => NPR::Entity::Link
+      has_many "links", :key => 'link', :class_name => NPR::Entity::Link
 
       #-------------------
 

--- a/lib/npr/version.rb
+++ b/lib/npr/version.rb
@@ -1,3 +1,3 @@
 module NPR
-  VERSION = "2.0.2"
+  VERSION = "3.0.0"
 end

--- a/spec/unit/entity/transcript_spec.rb
+++ b/spec/unit/entity/transcript_spec.rb
@@ -17,6 +17,6 @@ describe NPR::Entity::Transcript do
   end
 
   it "creates relations" do
-    @transcript.link.should be_a NPR::Entity::Link
+    @transcript.links[0].should be_a NPR::Entity::Link
   end
 end


### PR DESCRIPTION
For whatever reason, responses from the API now include a collection of links in a transcript.  This caused our NPR importer job, which depends on this gem, to fail on some shows.  The transcript 'model' has now been updated to support many links, and the `has_many` relation can now take either a single JSON link object or a collection of links in order to be backwards compatible.
